### PR TITLE
Fix panic caused by trying to deal with parsing incorrect size int.

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -60,7 +60,7 @@ mod parser {
             tag!(&[0x93u8]) >>
             tag!(b"NUMPY") >>
             tag!(&[0x01u8, 0x00]) >>
-            hdr: length_value!(le_i16, item) >>
+            hdr: length_value!(le_u16, item) >>
             (hdr)
         )
     );


### PR DESCRIPTION
A crashing input looks like `\x93NUMPY\x01\x00\xf8\xff`.

According to [the spec](https://github.com/numpy/numpy/blob/master/numpy/lib/format.py#L97), the bytes following `\x01\x00` should be an unsigned short int.

```
The next 2 bytes form a little-endian unsigned short int: the length of the header data HEADER_LEN.
```

`nom` was told to use a signed short int which would panic further code when given the wrong size.

Fixes #1 and found by [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz). It was found within ~30 executions but following the patch, I'm currently at 2 million with no crashes.