### PR TITLE
Allow OutFile to write to any Write + Seek

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,4 +136,4 @@ mod out_file;
 pub use serializable::Serializable;
 pub use header::{DType, Field};
 pub use npy_data::NpyData;
-pub use out_file::{to_file, OutFile};
+pub use out_file::{to_file, OutFile, NpyWriter};

--- a/src/out_file.rs
+++ b/src/out_file.rs
@@ -147,11 +147,13 @@ mod tests {
     fn write_simple() -> io::Result<()> {
         let mut cursor = Cursor::new(vec![]);
 
-        let mut writer = NpyWriter::begin(&mut cursor)?;
-        for x in vec![1.0, 3.0, 5.0] {
-            writer.push(&x)?;
+        {
+            let mut writer = NpyWriter::begin(&mut cursor)?;
+            for x in vec![1.0, 3.0, 5.0] {
+                writer.push(&x)?;
+            }
+            writer.finish()?;
         }
-        writer.finish()?;
 
         let raw_buffer = cursor.into_inner();
         let reader = NpyData::<f64>::from_bytes(&raw_buffer)?;
@@ -169,11 +171,13 @@ mod tests {
 
         // write to the cursor both before and after writing the file
         cursor.write_all(prefix)?;
-        let mut writer = NpyWriter::begin(&mut cursor)?;
-        for x in vec![1.0, 3.0, 5.0] {
-            writer.push(&x)?;
+        {
+            let mut writer = NpyWriter::begin(&mut cursor)?;
+            for x in vec![1.0, 3.0, 5.0] {
+                writer.push(&x)?;
+            }
+            writer.finish()?;
         }
-        writer.finish()?;
         cursor.write_all(suffix)?;
 
         // check that `OutFile` did not interfere with our extra writes


### PR DESCRIPTION
This is a small thing I need for some of the unit tests I'm adding to #15.  

In order to be backwards compatible, `OutFile` becomes a type alias for a new, more general type:

```rust
pub struct NpyWriter<T: npy::Serializable, W: io::Write + io::Seek> { ... }

impl<T: npy::Serializable, W: io::Write + io::Seek> NpyWriter {
    pub fn begin(W) -> io::Result<Self>;
    pub fn push(&mut self, &T) -> io::Result<()>;
    pub fn finish(self) -> io::Result<()>;
}

pub type OutFile<T> = NpyWriter<T, BufWriter<File>>;
```

`close` was renamed to `finish` to avoid suggesting that it closes any resources.  `OutFile::close` still exists as an alias for `finish`.